### PR TITLE
Check for a valid extension when loading commands

### DIFF
--- a/rebolbot.r3
+++ b/rebolbot.r3
@@ -23,7 +23,9 @@ command-dir: %commands/
 do sync-commands: func [] [
     clear head lib/commands: []
     foreach command read command-dir [
-        append lib/commands cmd: import/no-lib rejoin [command-dir command]
+        if system/options/default-suffix = suffix? command [
+            append lib/commands cmd: import/no-lib rejoin [command-dir command]
+        ]
     ]
 ]
 


### PR DESCRIPTION
Some systems might create some hidden files (like `.DS_Store` files under Mac OS X), causing the script to fail.

Commands can now be deactivated by changing the extension.
