### PR TITLE
Remove %twitter.r3 dependency 

### DIFF
--- a/rebolbot.r3
+++ b/rebolbot.r3
@@ -7,7 +7,6 @@ Rebol [
     Notes:      {You'll need to capture your own cookie and fkey using wireshark or similar.}
     License:    'Apache2
     Needs:      [
-                    %twitter.r3
                     %bot-api.r3 
                     http://reb4.me/r3/altjson 
                     http://reb4.me/r3/altxml


### PR DESCRIPTION
This file is only required by the `tweet` command, and is not required by the bot itself.
